### PR TITLE
Fix Send button shrinking on long text input in chat bar

### DIFF
--- a/styles/basic.css
+++ b/styles/basic.css
@@ -124,7 +124,8 @@ div[data-chatbotui-type="ChatInput"]:empty::after {
   opacity: 0.5;
 }
 button[data-chatbotui-type="ChatSendButton"] {
-  width: 2rem;
+  max-width: 2rem;
+  min-width: 2rem;
   height: 2rem;
   margin-bottom: 0.5rem;
   margin-top: auto;


### PR DESCRIPTION
This change replaces `width: 2rem;` with `min-width: 2rem; max-width: 2rem;` in the chat bar's CSS to prevent the Send button from shrinking when entering long multi-line text. This ensures consistent button sizing.

Resolves #5.